### PR TITLE
Remove dependency on name-service

### DIFF
--- a/greeting-service/pom.xml
+++ b/greeting-service/pom.xml
@@ -45,14 +45,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-rx-java</artifactId>
     </dependency>
-
-    <dependency>
-      <!-- for ordering purpose only -->
-      <groupId>${project.groupId}</groupId>
-      <artifactId>name-service</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
 


### PR DESCRIPTION
While building in s2i, the following error is displayed: 
```
Caused by: org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact io.openshift.booster:name-service:jar:1.0.0-SNAPSHOT in central (https://repo1.maven.org/maven2)
at org.eclipse.aether.connector.basic.ArtifactTransportListener.transferFailed(ArtifactTransportListener.java:39)
at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:355)
at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run(RunnableErrorForwarder.java:67)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
```

This PR removes the dependency on the name-service since it is built with 
```
mvn -Dmaven.repo.local=/tmp/artifacts/m2 -s /tmp/artifacts/configuration/settings.xml -e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga -Dfabric8.skip=true package --batch-mode -Djava.net.preferIPv4Stack=true -pl greeting-service
```