### PR TITLE
Fix integration tests

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -47,6 +47,38 @@
 							<profile>aggregate</profile>
 						</configuration>
 					</plugin>
+
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-resources-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>copy-image-streams</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>copy-resources</goal>
+								</goals>
+								<configuration>
+									<outputDirectory>${project.build.directory}</outputDirectory>
+									<resources>
+										<resource>
+											<directory>${project.parent.basedir}/name-service/target</directory>
+											<includes>
+												<include>*-is.yml</include>
+											</includes>
+										</resource>
+										<resource>
+											<directory>${project.parent.basedir}/greeting-service/target</directory>
+											<includes>
+												<include>*-is.yml</include>
+											</includes>
+										</resource>
+									</resources>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-failsafe-plugin</artifactId>

--- a/integration-tests/src/test/java/io/openshift/booster/OpenShiftIT.java
+++ b/integration-tests/src/test/java/io/openshift/booster/OpenShiftIT.java
@@ -18,6 +18,7 @@
 
 package io.openshift.booster;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.arquillian.cube.openshift.impl.enricher.RouteURL;
@@ -29,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import io.vertx.circuitbreaker.CircuitBreakerState;
 import io.vertx.core.json.JsonObject;
 
+import static com.jayway.restassured.RestAssured.get;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static com.jayway.awaitility.Awaitility.await;
 
@@ -55,6 +57,18 @@ public class OpenShiftIT {
 
 	@RouteURL(GREETING_SERVICE_APP)
 	private URL greetingServiceUrl;
+
+	@Before
+	public void setup() {
+		await().pollInterval(1, TimeUnit.SECONDS).atMost(5, TimeUnit.MINUTES).until(() -> {
+			try {
+				return get(greetingServiceUrl.toExternalForm() + "health").getStatusCode() == 200
+						&& get(nameServiceUrl.toExternalForm() + "health").getStatusCode() == 200;
+			} catch (Exception ignored) {
+				return false;
+			}
+		});
+	}
 
 	@Test
 	public void testThatCircuitBreakerIsClosedByDefault() throws InterruptedException {

--- a/integration-tests/src/test/resources/arquillian.xml
+++ b/integration-tests/src/test/resources/arquillian.xml
@@ -4,9 +4,8 @@
                http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
   <extension qualifier="openshift">
-    <property name="namespace.use.current">false</property>
+    <property name="namespace.use.current">true</property>
     <property name="env.init.enabled">true</property>
-    <property name="enableImageStreamDetection">true</property>
-    <property name="env.dependencies">file://${nameServiceIS} file://${greetingServiceIS}</property>
+    <property name="enableImageStreamDetection">false</property>
   </extension>
 </arquillian>


### PR DESCRIPTION
`name-service` and `greeting-service` imagestream files are now copied over to `integration-tests` target dir instead of applying them directly through Arquillian Cube config file. This is done just before the integration tests run.